### PR TITLE
Out-of-app notifications

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     ;; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/clojure "1.10.0-alpha8"]
     ;; Command-line parsing https://github.com/clojure/tools.cli
-    [org.clojure/tools.cli "0.4.0"] 
+    [org.clojure/tools.cli "0.4.1"] 
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.7.0"]
     ;; Web application library https://github.com/ring-clojure/ring

--- a/src/dev.clj
+++ b/src/dev.clj
@@ -1,6 +1,7 @@
 (ns dev
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.namespace.repl :as ctnrepl]
+            [oc.lib.db.pool :as pool]
             [oc.notify.config :as c]
             [oc.notify.app :as app]
             [oc.notify.components :as components]))
@@ -20,6 +21,9 @@
                                                                       :access-key c/aws-access-key-id
                                                                       :secret-key c/aws-secret-access-key}}})))))
 
+(defn bind-conn! []
+  (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
+
 (defn- start⬆ []
   (alter-var-root #'system component/start))
 
@@ -34,8 +38,10 @@
   ([port]
   (init port)
   (start⬆)
+  (bind-conn!)
   (app/echo-config port)
   (println (str "Now serving notifications from the REPL.\n"
+                "A DB connection is available with: conn\n"
                 "When you're ready to stop the system, just type: (stop)\n"))
   port))
 

--- a/src/oc/notify/async/bot.clj
+++ b/src/oc/notify/async/bot.clj
@@ -1,0 +1,65 @@
+(ns oc.notify.async.bot
+  "Publish Slack bot triggers to AWS SQS."
+  (:require [if-let.core :refer (when-let*)]
+            [amazonica.aws.sqs :as sqs]
+            [taoensso.timbre :as timbre]
+            [schema.core :as schema]
+            [oc.lib.db.common :as db-common]
+            [oc.lib.schema :as lib-schema]
+            [oc.notify.config :as config]
+            [oc.notify.resources.notification :as notification]))
+
+(def BotTrigger 
+  "All Slack bot triggers have the following properties."
+  {
+    :type (schema/enum "notify")
+    :bot {
+       :token lib-schema/NonBlankStr
+       :id lib-schema/NonBlankStr
+       :slack-org-id lib-schema/NonBlankStr
+    }
+    :receiver {
+      :type (schema/enum :user)
+      :id lib-schema/NonBlankStr
+  }})
+
+(def NotifyTrigger
+  (merge BotTrigger {
+    :user-id lib-schema/UniqueID
+    (schema/optional-key :last-name) schema/Str
+    (schema/optional-key :first-name) schema/Str
+    (schema/optional-key :name) schema/Str
+    (schema/optional-key :timezone) (schema/maybe schema/Str)
+    :org {schema/Any schema/Any}
+    :status schema/Str
+    :notification notification/Notification}))
+
+(defn ->trigger [conn notification org user]
+  (when-let* [slack-user (first (vals (:slack-users user)))
+              slack-bot (db-common/read-resource conn "slack_orgs" (:slack-org-id slack-user))]
+    (merge {
+      :type "notify"
+      :bot {
+        :token (:bot-token slack-bot)
+        :id (:bot-user-id slack-bot)
+        :slack-org-id (:slack-org-id slack-user)
+      }
+      :receiver {
+        :type :user
+        :id (:id slack-user)
+      }
+      :notification notification
+      :org (dissoc org :author :authors :viewers :created-at :updated-at :promoted)}
+      (select-keys user [:user-id :last-name :first-name :name :timezone :status]))))
+
+(defn send-trigger! [trigger]
+  (timbre/info "Bot request to queue:" config/aws-sqs-bot-queue)
+  (timbre/trace "Bot request:" trigger)
+  (schema/validate NotifyTrigger trigger)
+  (timbre/info "Sending request to queue:" config/aws-sqs-bot-queue)
+  (sqs/send-message
+    {:access-key config/aws-access-key-id
+     :secret-key config/aws-secret-access-key}
+     config/aws-sqs-bot-queue
+     trigger)
+  (timbre/info "Request sent to:" config/aws-sqs-bot-queue))

--- a/src/oc/notify/async/email.clj
+++ b/src/oc/notify/async/email.clj
@@ -14,7 +14,7 @@
    (schema/optional-key :last-name) schema/Str
    (schema/optional-key :first-name) schema/Str
    (schema/optional-key :name) schema/Str
-   (schema/optional-key :timezone) schema/Str
+   (schema/optional-key :timezone) (schema/maybe schema/Str)
    :org {schema/Any schema/Any}
    :status schema/Str
    :notification notification/Notification})

--- a/src/oc/notify/async/user.clj
+++ b/src/oc/notify/async/user.clj
@@ -9,7 +9,8 @@
             [taoensso.timbre :as timbre]
             [oc.lib.db.pool :as pool]
             [oc.lib.db.common :as db-common]
-            [oc.notify.async.email :as email]))
+            [oc.notify.async.email :as email]
+            [oc.notify.async.bot :as bot]))
 
 ;; ----- core.async -----
 
@@ -35,7 +36,7 @@
       (timbre/info "Handle user message for:" user-id)
       (if-let [notify-user (db-common/read-resource conn "users" user-id)]
         (case (:digest-medium notify-user)
-          ;"slack" (bot/send-trigger! (bot/->trigger notification notify-user))
+          "slack" (bot/send-trigger! (bot/->trigger conn notification org notify-user))
           "email" (email/send-trigger! (email/->trigger notification org notify-user))
           :else (timbre/info "Skipping out-of-app notification for user:" user-id))
         (timbre/warn "Notification for non-existent user:" user-id)))))


### PR DESCRIPTION
Requires:

https://github.com/open-company/open-company-email/pull/21

and

https://github.com/open-company/open-company-bot/pull/32

NB: There is a small punchlist of items for notifications here that aren't included in this: https://trello.com/c/BeqO4GX1

To test:

Need 2 users, a mentioner and a mentionee. At least the mentionee should be a Slack user. Org should have the bot.

Goal is to test out-of-app notifications for the 3 notification types, and the 2 notification settings. So...

Create a post with the mentionee.

Set the mentionee's notifaction setting to "Slack" in the personal profile:

- [x] Comment on their post with the mentioner - received a Slack message?
- [x] Create a comment that mentions them with the mentioner - received a Slack message?
- [x] Create a post that mentions them with the mentioner - received a Slack message?

Set the mentionee's notifaction setting to "Email" in the personal profile:

- [x] Comment on their post with the mentioner - received an email message?
- [x] Create a comment that mentions them with the mentioner - received an email message?
- [x] Create a post that mentions them with the mentioner - received an email message?

All righty...

- [x] Merge 3
- [x] Deploy 3
- [ ] Eat 3 lunches

