### PR TITLE
Require authentication with jwt token.

### DIFF
--- a/src/oc/notify/config.clj
+++ b/src/oc/notify/config.clj
@@ -62,6 +62,8 @@
 (defonce aws-sqs-bot-queue (env :aws-sqs-bot-queue))
 (defonce aws-sqs-notify-queue (env :aws-sqs-notify-queue))
 
+(defonce passphrase (env :open-company-auth-passphrase))
+
 ;; ----- Notify Service -----
 
 (defonce notification-ttl (or (env :oc-notification-ttl) 30)) ; days


### PR DESCRIPTION
Before you could use the service unauthenticated. This adds authentication with a JWT.

Use https://github.com/open-company/open-company-web/pull/704 to test the authentication.

Depends on https://github.com/belucid/open-company-infrastructure/pull/87
