### PR TITLE
Send entry title with notification if post data is available.

### DIFF
--- a/src/oc/notify/app.clj
+++ b/src/oc/notify/app.clj
@@ -78,6 +78,7 @@
         entry-key (if comment? :resource-uuid :uuid)
         entry-id (or (-> msg-body :content :new entry-key) ; new or update
                      (-> msg-body :content :old entry-key)) ; delete
+        entry-title (-> msg-body :content :new :headline)
         secure-uuid (or (:secure-uuid msg-body) ; interaction
                         (or (-> msg-body :content :new :secure-uuid) ; post new or update
                             (-> msg-body :content :old :secure-uuid))) ; post delete
@@ -112,9 +113,9 @@
             (if (= (:user-id mention) author-id) ; check for a self-mention
               (timbre/info "Skipping notification creation for self-mention.")
               (let [notification (if comment?
-                                    (notification/->Notification mention org-id board-id entry-id secure-uuid interaction-id
+                                    (notification/->Notification mention org-id board-id entry-id entry-title secure-uuid interaction-id
                                                                  change-at author)
-                                    (notification/->Notification mention org-id board-id entry-id secure-uuid change-at author))]
+                                    (notification/->Notification mention org-id board-id entry-id entry-title secure-uuid change-at author))]
                 (>!! persistence/persistence-chan {:notify true
                                                    :org org
                                                    :notification notification})))))))
@@ -123,7 +124,7 @@
     (when (and comment? add?)
       (timbre/info "Proccessing comment on a post...")
       (let [publisher (:item-publisher msg-body)
-            notification (notification/->Notification publisher new-body org-id board-id entry-id secure-uuid
+            notification (notification/->Notification publisher new-body org-id board-id entry-id entry-title secure-uuid
                                                       interaction-id change-at author)]
         (if (= (:user-id publisher) author-id) ; check for a self-comment
           (timbre/info "Skipping notification creation for self-comment.")

--- a/src/oc/notify/resources/notification.clj
+++ b/src/oc/notify/resources/notification.clj
@@ -23,6 +23,7 @@
   :org-id lib-schema/UniqueID
   :board-id lib-schema/UniqueID
   :entry-id lib-schema/UniqueID
+  (schema/optional-key :entry-title) schema/Str
   :secure-uuid lib-schema/UniqueID
   (schema/optional-key :interaction-id) lib-schema/UniqueID
   :notify-at lib-schema/ISO8601
@@ -39,6 +40,7 @@
    org-id :- lib-schema/UniqueID
    board-id :- lib-schema/UniqueID
    entry-id :- lib-schema/UniqueID
+   entry-title
    secure-uuid :- lib-schema/UniqueID
    change-at :- lib-schema/ISO8601
    author :- lib-schema/Author]
@@ -46,6 +48,7 @@
     :org-id org-id
     :board-id board-id
     :entry-id entry-id
+    :entry-title (if (nil? entry-title) "comment" entry-title)
     :secure-uuid secure-uuid
     :notify-at change-at
     :content (:parent mention)
@@ -53,8 +56,8 @@
     :author author})
 
   ;; arity 8: a mention in a comment
-  ([mention org-id board-id entry-id secure-id interaction-id :- lib-schema/UniqueID change-at author]
-  (assoc (->Notification mention org-id board-id entry-id secure-id change-at author)
+  ([mention org-id board-id entry-id entry-title secure-id interaction-id :- lib-schema/UniqueID change-at author]
+     (assoc (->Notification mention org-id board-id entry-id entry-title secure-id change-at author)
     :interaction-id interaction-id))
 
   ;; arity 9: a comment on a post
@@ -63,6 +66,7 @@
    org-id :- lib-schema/UniqueID
    board-id :- lib-schema/UniqueID
    entry-id :- lib-schema/UniqueID
+   entry-title
    secure-uuid :- lib-schema/UniqueID
    interaction-id :- lib-schema/UniqueID
    change-at :- lib-schema/ISO8601
@@ -71,6 +75,7 @@
     :org-id org-id
     :board-id board-id
     :entry-id entry-id
+    :entry-title (if (nil? entry-title) "comment" entry-title)
     :secure-uuid secure-uuid
     :interaction-id interaction-id
     :notify-at change-at


### PR DESCRIPTION
This change sends post title data so that the bot and email service can use it for notifications.