### PR TITLE
Add info to build id token.

### DIFF
--- a/src/oc/notify/async/bot.clj
+++ b/src/oc/notify/async/bot.clj
@@ -29,6 +29,8 @@
     (schema/optional-key :last-name) schema/Str
     (schema/optional-key :first-name) schema/Str
     (schema/optional-key :name) schema/Str
+    (schema/optional-key :avatar-url) (schema/maybe schema/Str)
+    (schema/optional-key :teams) (schema/maybe schema/Any)
     (schema/optional-key :timezone) (schema/maybe schema/Str)
     :org {schema/Any schema/Any}
     :status schema/Str
@@ -50,7 +52,7 @@
       }
       :notification notification
       :org (dissoc org :author :authors :viewers :created-at :updated-at :promoted)}
-      (select-keys user [:user-id :last-name :first-name :name :timezone :status]))))
+      (select-keys user [:user-id :last-name :first-name :name :avatar-url :teams :timezone :status]))))
 
 (defn send-trigger! [trigger]
   (timbre/info "Bot request to queue:" config/aws-sqs-bot-queue)

--- a/src/oc/notify/async/email.clj
+++ b/src/oc/notify/async/email.clj
@@ -14,6 +14,8 @@
    (schema/optional-key :last-name) schema/Str
    (schema/optional-key :first-name) schema/Str
    (schema/optional-key :name) schema/Str
+   (schema/optional-key :avatar-url) (schema/maybe schema/Str)
+   (schema/optional-key :teams) (schema/maybe schema/Any)
    (schema/optional-key :timezone) (schema/maybe schema/Str)
    :org {schema/Any schema/Any}
    :status schema/Str
@@ -25,7 +27,7 @@
     :to (:email user)
     :notification notification
     :org (dissoc org :author :authors :viewers :created-at :updated-at :promoted)}
-    (select-keys user [:user-id :last-name :first-name :name :timezone :status])))
+    (select-keys user [:user-id :last-name :first-name :name :avatar-url :teams :timezone :status])))
 
 (defn send-trigger! [trigger]
   (timbre/info "Email request to queue:" config/aws-sqs-email-queue)


### PR DESCRIPTION
This change adds needed information for the bot and email service to generate id tokens. 

To test:

- Mention someone in a post that has email notifications turned on.
- [x] does the link to the post in the email have an id token?
- [x] does clicking the link take you to the post as the user with the email?
- do the above for comments

- Mention someone in a post that has slack notifications turned on.
- [x] does the link to the post in the slack message have an id token?
- [x] does clicking the link take you to the post as the slack user?
- do the above for comments
