### PR TITLE
Reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Server sends a `:user/notifications` message over the socket with a sequence of 
       :interaction-id "4444-4444-4444"
       :content "Reply to me."
       :author {:user-id "1234-5678-1234", :name "Wile E. Coyote", :avatar-url "http://www.emoticonswallpapers.com/avatar/cartoons/Wiley-Coyote-Dazed.jpg"}
-      :mention false
+      :mention? false
       :notify-at "2018-07-31T15:07:49.699Z"
     }
     {
@@ -238,7 +238,7 @@ Server sends a `:user/notifications` message over the socket with a sequence of 
       :entry-id "3333-3333-3333"
       :interaction-id "5555-5555-5555"
       :author {:user-id "1234-5678-1234", :name "Wile E. Coyote", :avatar-url "http://www.emoticonswallpapers.com/avatar/cartoons/Wiley-Coyote-Dazed.jpg"}
-      :mention false
+      :mention? false
       :notify-at "2018-07-31T15:08:48.162Z"
     }]
   }

--- a/project.clj
+++ b/project.clj
@@ -83,7 +83,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.4" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
+        [midje "1.9.6" :exclusions [joda-time org.clojure/tools.macro clj-time commons-codec]] 
         ;; Clojure WebSocket client https://github.com/cch1/http.async.client
         [http.async.client "1.3.0"]
         ;; Test Ring requests https://github.com/weavejester/ring-mock

--- a/src/oc/notify/app.clj
+++ b/src/oc/notify/app.clj
@@ -46,7 +46,7 @@
 
 (defn sqs-handler
   "
-  Handle an incoming SQS message from storage to the notify service.
+  Handle an incoming SQS message to the notify service.
 
   {
     :notification-type 'add|update|delete'

--- a/src/oc/notify/async/bot.clj
+++ b/src/oc/notify/async/bot.clj
@@ -12,7 +12,7 @@
 (def BotTrigger 
   "All Slack bot triggers have the following properties."
   {
-    :type (schema/enum "notify")
+    :type (schema/enum "notify" "reminder-alert" "reminder-notification")
     :bot {
        :token lib-schema/NonBlankStr
        :id lib-schema/NonBlankStr
@@ -40,7 +40,7 @@
   (when-let* [slack-user (first (vals (:slack-users user)))
               slack-bot (db-common/read-resource conn "slack_orgs" (:slack-org-id slack-user))]
     (merge {
-      :type "notify"
+      :type (if (:reminder notification) "reminder-notification" "notify")
       :bot {
         :token (:bot-token slack-bot)
         :id (:bot-user-id slack-bot)

--- a/src/oc/notify/async/email.clj
+++ b/src/oc/notify/async/email.clj
@@ -8,7 +8,7 @@
             [oc.notify.resources.notification :as notification]))
 
 (def EmailTrigger
-  {:type (schema/enum "notify")
+  {:type (schema/enum "notify" "reminder-alert" "reminder-notification")
    :user-id lib-schema/UniqueID
    :to lib-schema/EmailAddress
    (schema/optional-key :last-name) schema/Str
@@ -23,7 +23,7 @@
 
 (defn ->trigger [notification org user]
   (merge {
-    :type "notify"
+    :type (if (:reminder notification) "reminder-notification" "notify")
     :to (:email user)
     :notification notification
     :org (dissoc org :author :authors :viewers :created-at :updated-at :promoted)}

--- a/src/oc/notify/async/user.clj
+++ b/src/oc/notify/async/user.clj
@@ -35,7 +35,9 @@
           org (:org message)]
       (timbre/info "Handle user message for:" user-id)
       (if-let [notify-user (db-common/read-resource conn "users" user-id)]
-        (case (:digest-medium notify-user)
+        (case (if (= (keyword (:notification-type notification)) :notify)
+                        (:notify-medium notify-user)
+                        (:reminder-medium notify-user))
           "slack" (bot/send-trigger! (bot/->trigger conn notification org notify-user))
           "email" (email/send-trigger! (email/->trigger notification org notify-user))
           :else (timbre/info "Skipping out-of-app notification for user:" user-id))

--- a/src/oc/notify/db/migrations/1548084671263_update_reminder.edn
+++ b/src/oc/notify/db/migrations/1548084671263_update_reminder.edn
@@ -1,0 +1,42 @@
+(ns oc.notify.db.migrations.update-reminder
+  (:require [taoensso.faraday :as far]
+            [oc.lib.db.migrations :as m]
+            [oc.notify.config :as config]
+            [oc.notify.resources.notification :as notification]))
+
+(defn update-notification-schema
+  []
+  (println (str "Scanning " notification/table-name "..."))
+  (let [idx (atom 0)
+        results1 (far/scan config/dynamodb-opts notification/table-name {:attr-conds {:mention [:eq true]}})
+        results2 (far/scan config/dynamodb-opts notification/table-name {:attr-conds {:mention [:eq false]}})]
+    (doseq [r (concat results1 results2)]
+      ;; Update :mention property to be :mention?
+      (println (str "   " @idx " - Fixing notification: " r))
+      (swap! idx inc)
+      (far/update-item config/dynamodb-opts notification/table-name
+         {:user_id (:user_id r)
+          :notify_at (:notify_at r)}
+         {:update-expr "SET #k = :v"
+          :expr-attr-names {"#k" "mention?"}
+          :expr-attr-vals  {":v" (:mention r)}
+          :return :none})
+      (far/update-item config/dynamodb-opts notification/table-name
+         {:user_id (:user_id r)
+          :notify_at (:notify_at r)}
+         {:update-map {"mention" [:delete]}})
+      ;; Default old notifications to reminder? as false
+      (when-not (:reminder? r))
+        (far/update-item config/dynamodb-opts notification/table-name
+           {:user_id (:user_id r)
+            :notify_at (:notify_at r)}
+           {:update-expr "SET #k = :v"
+            :expr-attr-names {"#k" "reminder?"}
+            :expr-attr-vals  {":v" false}
+            :return :none}))))
+
+;; NB: The fact that these migrations have been run already does not currently persist, so the up method
+;; needs to be idempotent
+(defn up [dynamodb-opts]
+  (update-notification-schema)
+  true) ; return true on success

--- a/src/oc/notify/resources/notification.clj
+++ b/src/oc/notify/resources/notification.clj
@@ -41,7 +41,7 @@
   :mention? (schema/pred false?)
   :reminder? (schema/pred true?)}))
 
-;; ----- Constructor -----
+;; ----- Constructors -----
 
 (schema/defn ^:always-validate ->ReminderNotification :- ReminderNotification
   [org-id reminder]

--- a/src/oc/notify/resources/notification.clj
+++ b/src/oc/notify/resources/notification.clj
@@ -20,19 +20,40 @@
 (def Notification {
   :user-id lib-schema/UniqueID
   :org-id lib-schema/UniqueID
+  :notify-at lib-schema/ISO8601
+  :mention? schema/Bool
+  :reminder? schema/Bool
+  :author lib-schema/Author
+  schema/Keyword schema/Any})
+
+(def InteractionNotification (merge Notification {
   :board-id lib-schema/UniqueID
   :entry-id lib-schema/UniqueID
   (schema/optional-key :entry-title) schema/Str
   :secure-uuid lib-schema/UniqueID
   (schema/optional-key :interaction-id) lib-schema/UniqueID
-  :notify-at lib-schema/ISO8601
   :content lib-schema/NonBlankStr
-  :mention schema/Bool
-  :author lib-schema/Author})
+  :mention? schema/Bool
+  :reminder? (schema/pred false?)}))
+
+(def ReminderNotification (merge Notification {
+  :reminder {schema/Keyword schema/Any}
+  :mention? (schema/pred false?)
+  :reminder? (schema/pred true?)}))
 
 ;; ----- Constructor -----
 
-(schema/defn ^:always-validate ->Notification :- Notification
+(schema/defn ^:always-validate ->ReminderNotification :- ReminderNotification
+  [org-id reminder]
+  {:user-id (-> reminder :assignee :user-id)
+   :org-id org-id
+   :notify-at (:updated-at reminder)
+   :reminder reminder
+   :mention? false
+   :reminder? true
+   :author (:author reminder)})
+
+(schema/defn ^:always-validate ->InteractionNotification :- InteractionNotification
   
   ;; arity 7: a mention in a post
   ([mention :- Mention
@@ -51,12 +72,13 @@
     :secure-uuid secure-uuid
     :notify-at change-at
     :content (:parent mention)
-    :mention true
+    :mention? true
+    :reminder? false
     :author author})
 
   ;; arity 8: a mention in a comment
   ([mention org-id board-id entry-id entry-title secure-id interaction-id :- lib-schema/UniqueID change-at author]
-     (assoc (->Notification mention org-id board-id entry-id entry-title secure-id change-at author)
+     (assoc (->InteractionNotification mention org-id board-id entry-id entry-title secure-id change-at author)
     :interaction-id interaction-id))
 
   ;; arity 9: a comment on a post
@@ -79,10 +101,9 @@
     :interaction-id interaction-id
     :notify-at change-at
     :content comment-body
-    :mention false
+    :mention? false
+    :reminder? false
     :author author}))
-
-
 
 ;; ----- DB Operations -----
 


### PR DESCRIPTION
[Trello](https://trello.com/c/u1tvLZVO)

For code review, this PR:

- updates the notification schema to account for reminder alerts and reminder notifications
   - `mention` -> `mention?`
   - adds `reminder?`
   - breaks the schema into a "super", `Notification`, and 2 "subs", `InteractionNotification` and `ReminderNotification` with data constructors for both
- includes a DynamoDB migration
   - `mention` -> `mention?`
   - adds `reminder?` defaulted to `false`
- handles a new (direct) SQS message from reminder service for reminder alerts and reminder notifications
- passes on the new notification types to Email or Bot service based on the user preference for reminder notifications, `reminder-medium`

Before testing locally, ensure you run `lein migrate-db`. This is handled automatically on the servers.

Test from main PR: open-company/open-company-storage#184
