### PR TITLE
Fix dupe notifications for a post author mentioned in a comment.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     [org.apache.httpcomponents/httpclient "4.5.7"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.36"]
+    [open-company/lib "0.16.35"] ; DON'T upgrade past 0.16.35 until further notice, 403's on socket connect
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     [org.apache.httpcomponents/httpclient "4.5.7"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.33"]
+    [open-company/lib "0.16.36"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/src/oc/notify/async/user.clj
+++ b/src/oc/notify/async/user.clj
@@ -30,14 +30,15 @@
 
   ([db-pool message :guard :notify]
   (pool/with-pool [conn db-pool]
-    (let [user-id (:user-id message)
+    (let [reminder? (:reminder? message)
+          user-id (:user-id message)
           notification (:notification message)
           org (:org message)]
       (timbre/info "Handle user message for:" user-id)
       (if-let [notify-user (db-common/read-resource conn "users" user-id)]
-        (case (if (= (keyword (:notification-type notification)) :notify)
-                        (:notification-medium notify-user)
-                        (:reminder-medium notify-user))
+        (case (if reminder?
+                (:reminder-medium notify-user)
+                (:notification-medium notify-user))
           "slack" (bot/send-trigger! (bot/->trigger conn notification org notify-user))
           "email" (email/send-trigger! (email/->trigger notification org notify-user))
           :else (timbre/info "Skipping out-of-app notification for user:" user-id))

--- a/src/oc/notify/async/user.clj
+++ b/src/oc/notify/async/user.clj
@@ -36,7 +36,7 @@
       (timbre/info "Handle user message for:" user-id)
       (if-let [notify-user (db-common/read-resource conn "users" user-id)]
         (case (if (= (keyword (:notification-type notification)) :notify)
-                        (:notify-medium notify-user)
+                        (:notification-medium notify-user)
                         (:reminder-medium notify-user))
           "slack" (bot/send-trigger! (bot/->trigger conn notification org notify-user))
           "email" (email/send-trigger! (email/->trigger notification org notify-user))


### PR DESCRIPTION
[Trello](https://trello.com/c/60ZkIVU0)

Review with and deploy with Email PR: https://github.com/open-company/open-company-email/pull/46

Review and deploy with Bot PR: https://github.com/open-company/open-company-bot/pull/65

To test you need 2 Slack users of the same org: user1, user2

- Set both users notification to Email
- write a post as user1
- [x] user1 comments on the post, nothing happens?
- [x] user1 comments on the post, mentioning user 2, user2 gets a mention notification?
- [x] user2 comments on the post, does user1 get a comment notification?
- [x] user2 comments on the post mentioning user1, user1 gets a mention notification of the mention but not of the comment (only 1 notification)?
- Set both users notification to Slack
- Repeat the 4 commenting test steps above, check for some results in Slack
- Merge
- Deploy
- Adopt a ferret from your local shelter