### PR TITLE
Fix duplicated follow-up notification

### DIFF
--- a/src/oc/notify/lib/follow_up.clj
+++ b/src/oc/notify/lib/follow_up.clj
@@ -5,7 +5,8 @@
 (defn assigned-follow-ups
   "Returns newly assigned follow-ups that are not follow-ups for the author."
   [author prior-follow-ups current-follow-ups]
-  (let [prior (set (remove :completed prior-follow-ups))
-        current (set (remove :completed current-follow-ups))
-        new (set/difference current prior)]
+  (let [prior (set (map (comp :user-id :assignee) (remove :completed? prior-follow-ups)))
+        current (set (map (comp :user-id :assignee) (remove :completed? current-follow-ups)))
+        diff-set (set/difference current prior)
+        new (filter #(diff-set (-> % :assignee :user-id)) current-follow-ups)]
     (remove #(= (:user-id author) (-> % :assignee :user-id)) new)))


### PR DESCRIPTION
Bug:
- create a new post
- add follow-ups for your self (user A) and for user B
- publish it
- with user A expand the post
- complete the follow-up
- create the follow-up again with the button in top right corner
- user B gets another notification for a requested follow-up

To test:
- follow the bug steps above
- [x] user B gets the first notification of user A requesting him to follow-up?
- [x] user B doesn't get a second notification?