### PR TITLE
Summarize content in push notification bodies for richer context

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
     [org.apache.httpcomponents/httpclient "4.5.10"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.17.19-alpha7"]
+    [open-company/lib "0.17.19-alpha9"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/src/oc/notify/lib/expo.clj
+++ b/src/oc/notify/lib/expo.clj
@@ -55,11 +55,51 @@
       :else
       nil)))
 
+(defn notification-title
+  [notification user]
+  (let [reminder?         (:reminder? notification)
+        follow-up?        (:follow-up? notification)
+        follow-up-data    (when follow-up?
+                            (:follow-up notification))
+        ;; reminder          (when reminder?
+        ;;                     (:reminder notification))
+        ;; notification-type (when reminder?
+        ;;                     (:notification-type reminder))
+        ;; reminder-assignee (when reminder?
+        ;;                     (:assignee reminder))
+        ]
+    (cond
+      (and follow-up?
+           follow-up-data
+           (not= (-> follow-up-data :author :user-id) (:user-id user))
+           (not (:completed? follow-up-data)))
+      (:entry-title notification)
+
+      ;; TODO: titles for reminders?
+      ;; (and reminder
+      ;;      (= notification-type "reminder-notification"))
+      ;; (str first-name " created a new reminder for you")
+      ;; (and reminder
+      ;;      (= notification-type "reminder-alert"))
+      ;; (str "Hi " (first (cstr/split (:name reminder-assignee) #"\s")) ", it's time to update your team")
+
+      (and (:mention? notification) (:interaction-id notification))
+      (:entry-title notification)
+
+      (:mention? notification)
+      (:entry-title notification)
+
+      (:interaction-id notification)
+      (:entry-title notification)
+      :else
+      nil)))
+
 (defn ->push-notification
   [notification user push-token]
   (when-let [body (notification-body notification user)]
     {:pushToken push-token
      :body      body
+     :title     (notification-title notification user)
      :data      notification}))
 
 (defn ->push-notifications

--- a/src/oc/notify/lib/expo.clj
+++ b/src/oc/notify/lib/expo.clj
@@ -5,22 +5,35 @@
             [oc.lib.lambda.common :as lambda]
             [oc.lib.user :as user-lib]
             [oc.notify.config :as config]
-            [taoensso.timbre :as timbre]))
+            [taoensso.timbre :as timbre]
+            [oc.lib.html :as lib-html]))
+
+(def ^:private max-content-length 100)
+
+(defn- summarize-content
+  [notification]
+  (let [summarize #(cstr/join (take max-content-length %))]
+    (some-> notification
+            :content
+            (lib-html/strip-html-tags :decode-entities? true)
+            cstr/trim
+            summarize)))
 
 (defn notification-body
   [notification user]
-  (let [reminder? (:reminder? notification)
-        follow-up? (:follow-up? notification)
-        follow-up-data (when follow-up?
-                         (:follow-up notification))
-        author (:author notification)
-        first-name (or (:first-name author) (first (cstr/split (:name author) #"\s")))
-        reminder (when reminder?
-                   (:reminder notification))
+  (let [reminder?         (:reminder? notification)
+        follow-up?        (:follow-up? notification)
+        follow-up-data    (when follow-up?
+                            (:follow-up notification))
+        author            (:author notification)
+        first-name        (or (:first-name author) (first (cstr/split (:name author) #"\s")))
+        reminder          (when reminder?
+                            (:reminder notification))
         notification-type (when reminder?
                             (:notification-type reminder))
         reminder-assignee (when reminder?
-                            (:assignee reminder))]
+                            (:assignee reminder))
+        extra-content     (summarize-content notification)]
     (cond
       (and follow-up?
            follow-up-data
@@ -34,11 +47,11 @@
            (= notification-type "reminder-alert"))
       (str "Hi " (first (cstr/split (:name reminder-assignee) #"\s")) ", it's time to update your team")
       (and (:mention? notification) (:interaction-id notification))
-      (str first-name " mentioned you in a comment")
+      (str first-name " mentioned you in a comment:\n" extra-content)
       (:mention? notification)
-      (str first-name " mentioned you")
+      (str first-name " mentioned you:\n" extra-content)
       (:interaction-id notification)
-      (str first-name " commented on your post")
+      (str first-name " commented on your post:\n" extra-content)
       :else
       nil)))
 


### PR DESCRIPTION
Depends upon changes in: https://github.com/open-company/open-company-notify/pull/18. Please review that PR before starting on this one.
Linked lib PR: https://github.com/open-company/open-company-lib/pull/74. These lib changes are also needed by #18, so again, review that one before this one. 

To test:

- Trigger a push notification via comment mention
- [x] Push notification content includes comment summary? No HTML in content?
- Trigger push notification via comment (no mention)
- [x] Push notification content includes comment summary? No HTML in content?
- Trigger push notification by mentioning a user in a post body
- [x] Push notification content includes comment summary? No HTML in content?
- Test the above cases using images, video embeds, other mentions, etc...
- [x] Do images/videos/etc all get stripped from the push notification summary? 